### PR TITLE
Fix mender repo path

### DIFF
--- a/plugins/playbooks/board_support/roles/mender/templates/mender.list
+++ b/plugins/playbooks/board_support/roles/mender/templates/mender.list
@@ -1,1 +1,1 @@
-deb [arch={{ edi_bootstrap_architecture }}] https://downloads.mender.io/repos/debian stable main
+deb [arch={{ edi_bootstrap_architecture }}] https://downloads.mender.io/repos/debian debian/bullseye/stable main


### PR DESCRIPTION
Fix path to mender repo according to their documentation. With the current path ansible fails with the following error:

```
TASK [mender : Install mender-client, mender-connect, mender-configure and jq.] ****************************************fatal: [edi-tmp-aac62ace0c2fc0929e20]: FAILED! => {"cache_update_time": 1644247414, "cache_updated": false, "changed": false, "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"      install 'mender-client' 'mender-connect' 'mender-configure' 'jq' -o APT::Install-Recommends=no' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n mender-client : Depends: libffi6 (>= 3.2) but it is not installable\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " mender-client : Depends: libffi6 (>= 3.2) but it is not installable"]}  ```